### PR TITLE
Correcting file extension for use with tests

### DIFF
--- a/PyDodo/tests/integration/test_flight_level.py
+++ b/PyDodo/tests/integration/test_flight_level.py
@@ -12,7 +12,7 @@ def test_flight_level():
     cmd = reset_simulation()
     assert cmd == True
 
-    resp = load_scenario("scenario/8.scn")
+    resp = load_scenario("scenario/8.SCN")
     assert resp == True
 
     assert current_flight_level("SCN1001") == 6096

--- a/PyDodo/tests/integration/test_manage_simulation.py
+++ b/PyDodo/tests/integration/test_manage_simulation.py
@@ -102,14 +102,14 @@ def test_load_bluesky():
     """
     resp = reset_simulation()
     assert resp == True
-    
-    resp = load_scenario("scenario/8.scn")
+
+    resp = load_scenario("scenario/8.SCN")
     assert resp == True
 
     resp = reset_simulation()
     assert resp == True
 
-    resp = load_scenario("scenario/8.scn", 1.5)
+    resp = load_scenario("scenario/8.SCN", 1.5)
     assert resp == True
 
 
@@ -122,4 +122,4 @@ def test_load_fail():
         load_scenario("")
 
     with pytest.raises(AssertionError):
-        load_scenario("scenario/8.scn", 0)
+        load_scenario("scenario/8.SCN", 0)


### PR DESCRIPTION
As outlined in https://github.com/alan-turing-institute/dodo/issues/67
the integration tests require the scenario file extension to be
uppercase when testing with docker.

With this change all tests pass.

Fixes #67 

 Changes to be committed:
	modified:   tests/integration/test_manage_simulation.py