### PR TITLE
[HOTFIX] Updating pytest dependency to fix error

### DIFF
--- a/PyDodo/requirements.txt
+++ b/PyDodo/requirements.txt
@@ -4,7 +4,7 @@ scipy
 pyproj
 aiohttp
 asyncio
-pytest==4.1.*
+pytest==5.2.0
 pandas>=0.25.0
 requests>=2.22.0
 pyyaml>=5.1


### PR DESCRIPTION
It was discovered in builds from #79 and #78 a failure has
occurred on Travis

Error:

    TypeError: attrib() got an unexpected keyword argument 'convert'

It appears that `pytest` seems to have the package `attrs` as a dependency.

REF:
    https://stackoverflow.com/questions/58189683/typeerror-attrib-got-an-unexpected-keyword-argument-convert

	modified:   requirements.txt