### PR TITLE
PyDodo minor fixes

### DIFF
--- a/PyDodo/pydodo/config_param.py
+++ b/PyDodo/pydodo/config_param.py
@@ -10,16 +10,16 @@ def find_config():
         """used for installs"""
         this_dir, this_filename = os.path.split(os.path.abspath(__file__))
         with open(os.path.join(this_dir, "config.yml"), "r") as ymlfile:
-            cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
+            cfg = yaml.safe_load(ymlfile)
     except:
         """used for development"""
         try:
             with open("../config.yml", "r") as ymlfile:
-                cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
+                cfg = yaml.safe_load(ymlfile)
         except:
             try:
                 with open("../../config.yml", "r") as ymlfile:
-                    cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
+                    cfg = yaml.safe_load(ymlfile)
             except:
                 raise FileNotFoundError("The config file is missing.")
     return cfg

--- a/PyDodo/pydodo/distance_measures.py
+++ b/PyDodo/pydodo/distance_measures.py
@@ -368,6 +368,8 @@ def get_separation(
         from_aircraft_id = [from_aircraft_id]
     if to_aircraft_id == None:
         to_aircraft_id = from_aircraft_id.copy()
+    if not isinstance(to_aircraft_id, list):
+        to_aircraft_id = [to_aircraft_id]
 
     pos_df = get_pos_df(from_aircraft_id, to_aircraft_id)
 

--- a/PyDodo/pydodo/distance_measures.py
+++ b/PyDodo/pydodo/distance_measures.py
@@ -364,12 +364,10 @@ def get_separation(
         "vertical",
         "euclidean",
     ], "Invalid value {} for measure".format(measure)
-    if to_aircraft_id == None:
-        to_aircraft_id = from_aircraft_id.copy()
     if not isinstance(from_aircraft_id, list):
         from_aircraft_id = [from_aircraft_id]
-    if not isinstance(to_aircraft_id, list):
-        to_aircraft_id = [to_aircraft_id]
+    if to_aircraft_id == None:
+        to_aircraft_id = from_aircraft_id.copy()
 
     pos_df = get_pos_df(from_aircraft_id, to_aircraft_id)
 

--- a/PyDodo/pydodo/metrics.py
+++ b/PyDodo/pydodo/metrics.py
@@ -44,7 +44,7 @@ def loss_of_separation(from_aircraft_id, to_aircraft_id):
         url,
         params={
             "name": "aircraft_separation",
-            "args": "{},{}".format(from_aircraft_id, to_aircraft_id)
+            "args": "{},{}".format(from_aircraft_id, to_aircraft_id),
         },
     )
     if resp.status_code == 200:

--- a/PyDodo/pydodo/metrics.py
+++ b/PyDodo/pydodo/metrics.py
@@ -44,7 +44,7 @@ def loss_of_separation(from_aircraft_id, to_aircraft_id):
         url,
         params={
             "name": "aircraft_separation",
-            "args": f"{from_aircraft_id},{to_aircraft_id}",
+            "args": "{},{}".format(from_aircraft_id, to_aircraft_id)
         },
     )
     if resp.status_code == 200:

--- a/PyDodo/requirements.txt
+++ b/PyDodo/requirements.txt
@@ -12,3 +12,4 @@ sphinx==1.8
 sphinx_rtd_theme>=0.4.3
 numpydoc==0.7
 sphinx-autorun
+wget

--- a/PyDodo/requirements.txt
+++ b/PyDodo/requirements.txt
@@ -7,7 +7,7 @@ asyncio
 pytest==5.2.0
 pandas>=0.25.0
 requests>=2.22.0
-pyyaml>=5.1
+pyyaml
 sphinx==1.8
 sphinx_rtd_theme>=0.4.3
 numpydoc==0.7

--- a/PyDodo/setup.py
+++ b/PyDodo/setup.py
@@ -10,10 +10,7 @@ with open("requirements.txt", "r") as f:
 
 
 def get_config(dir=None):
-    """
-    Downloads config file from GitHub and saves it in dir
-    (using either wget or curl).
-    """
+    """Downloads config file from GitHub and saves it in dir."""
     print("Getting the config file")
     config_url = (
         "https://raw.githubusercontent.com/alan-turing-institute/dodo/master/config.yml"

--- a/PyDodo/setup.py
+++ b/PyDodo/setup.py
@@ -1,4 +1,5 @@
 import os
+import wget
 from setuptools import setup, find_packages
 from setuptools.command.develop import develop as _develop
 from setuptools.command.install import install as _install
@@ -14,15 +15,13 @@ def get_config(dir=None):
     (using either wget or curl).
     """
     print("Getting the config file")
-    config = (
+    config_url = (
         "https://raw.githubusercontent.com/alan-turing-institute/dodo/master/config.yml"
     )
-    cmd = ["wget", config, "2>/dev/null", "||", " curl", "-O", config]
     if dir == None:
-        call(cmd)
+        wget.download(config_url)
     else:
-        # call(["wget", config], cwd=dir)
-        call(cmd, cwd=dir)
+        wget.download(config_url, dir)
 
 
 class develop(_develop):

--- a/PyDodo/setup.py
+++ b/PyDodo/setup.py
@@ -9,14 +9,20 @@ with open("requirements.txt", "r") as f:
 
 
 def get_config(dir=None):
+    """
+    Downloads config file from GitHub and saves it in dir
+    (using either wget or curl).
+    """
     print("Getting the config file")
     config = (
         "https://raw.githubusercontent.com/alan-turing-institute/dodo/master/config.yml"
     )
+    cmd = ["wget", config, "2>/dev/null", "||", " curl", "-O", config]
     if dir == None:
-        call(["wget", config])
+        call(cmd)
     else:
-        call(["wget", config], cwd=dir)
+        # call(["wget", config], cwd=dir)
+        call(cmd, cwd=dir)
 
 
 class develop(_develop):

--- a/PyDodo/tests/integration/test_create_scenario.py
+++ b/PyDodo/tests/integration/test_create_scenario.py
@@ -32,7 +32,7 @@ def test_create_scenario(rootdir):
     resp = reset_simulation()
     assert resp == True
 
-    resp = create_scenario(filename=f"{test_file}.scn", scenario=test_scenario)
+    resp = create_scenario(filename="{}.scn".format(test_file), scenario=test_scenario)
     assert resp == True
 
     resp = load_scenario(test_scenario)

--- a/PyDodo/tests/integration/test_separation_measures.py
+++ b/PyDodo/tests/integration/test_separation_measures.py
@@ -113,6 +113,10 @@ def test_separation(expected_great_circle):
         euclidean(from_ECEF, to_ECEF), 0.01
     )
 
+    pos5 = euclidean_separation(from_aircraft_id=aircraft_id_2)
+    assert isinstance(pos5, pd.DataFrame)
+    assert pos5.loc[aircraft_id_2, aircraft_id_2] == 0
+
 
 @pytest.mark.skipif(not bb_resp, reason="Can't connect to bluebird")
 def test_wrong_id():


### PR DESCRIPTION
- use yaml.safe_load() : safer than FullLoader and removes pyyaml>=5.1 requirement
- use python wget module
- remove f-Strings (requires python>=3.6)
- fix bug (and add test for) separation function